### PR TITLE
added --dockerport option, env variables PORT_xxxx=realport

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -16,6 +16,7 @@ if (argv.help || !image) {
   console.log('  --port,    -p  [8080]          (port to listen on)')
   console.log('  --docker,  -d  [$DOCKER_HOST]  (optional host of the docker daemon)')
   console.log('  --persist                      (allow persistance of /root in the containers)')
+  console.log('  --dockerport                   (expose a docker container port to dockerhost)')
   console.log('')
   return process.exit(argv.help ? 0 : 1)
 }
@@ -35,3 +36,4 @@ server.on('listening', function() {
 })
 
 server.listen(argv.port)
+


### PR DESCRIPTION
Hey, this is what we discussed in #3
I have added an extra container port that you can specify using --dockerport=5000
In the spawned container you will find these env variables:

PORT_80=xxxxx
PORT_8441=xxxxx
PORT_5000=xxxxxxx

If you don't specify --dockerport, it will create a default one (9000). 
I don't know how to find a range of free ports (if you want --dockerport to be an array rather than a scalar) using freeport,js, since you cannot put it in a loop as it is an async function. Maybe use find-free-port [1]? For a small project three ports is enough IMHO.

[1] https://www.npmjs.com/package/find-free-port