### PR TITLE
Add --pidslimit arg to limit max processes

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -18,12 +18,17 @@ if (argv.help || !image) {
   console.log('  --docker,  -d  [$DOCKER_HOST]  (optional host of the docker daemon)')
   console.log('  --persist                      (allow persistance of /root in the containers)')
   console.log('  --dockerport                   (expose a docker container port to dockerhost)')
+  console.log('  --pidslimit N                  (limit spawned containers to N number of processes)')
   console.log('')
   return process.exit(argv.help ? 0 : 1)
 }
 
 if (argv.hostNetworking) argv.beforeCreate = function (config) {
   config.HostConfig.NetworkMode = 'host'
+}
+
+if (argv.pidslimit) argv.beforeCreate = function (config) {
+  config.HostConfig.PidsLimit = argv.pidslimit
 }
 
 var server = docker(image, argv)


### PR DESCRIPTION
The Docker API has offered support for a HostConfig.PidsLimit parameter
to the POST /containers/create route since API version 1.23. This
parameter allows limiting the maximum number of simultaneous processes
within the container.

This feature requires Linux kernel 4.3 or later and pids cgroup support.
Docker API 1.23 is known to be supported in Docker Engine 1.11.2 and
later.

This feature was tested by running `./bin.js alpine --pidslimit 10` on
the host and then running the following inside the spawned container:

    / # for i in $(seq 15) ; do
    > eval "echo sleep \$i" ; sleep 10 &
    > done
    sleep 1
    sleep 2
    sleep 3
    sleep 4
    sleep 5
    sleep 6
    sleep 7
    sleep 8
    sleep 9
    /bin/sh: can't fork